### PR TITLE
Added cleanup function

### DIFF
--- a/ChartIQ/Charts/ChartIQView.swift
+++ b/ChartIQ/Charts/ChartIQView.swift
@@ -338,6 +338,18 @@ public class ChartIQView: UIView {
         NotificationCenter.default.addObserver(self, selector: #selector(ChartIQView.applicationDidBecomeActive), name: NSNotification.Name.UIApplicationDidBecomeActive, object: nil)
     }
     
+    /// Cleans up the message handlers in order to avoid a memory leak.
+    /// Should be called when the view is about to get deallocated (e.g. the deinit of its superview)    
+    public func cleanup() {
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: ChartIQCallbackMessage.accessibility.rawValue)
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: ChartIQCallbackMessage.newSymbol.rawValue)
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: ChartIQCallbackMessage.pullInitialData.rawValue)
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: ChartIQCallbackMessage.pullUpdateData.rawValue)
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: ChartIQCallbackMessage.pullPaginationData.rawValue)
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: ChartIQCallbackMessage.layout.rawValue)
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: ChartIQCallbackMessage.drawing.rawValue)
+    }
+    
     /// Sets your ROKO Mobi api id and url here.
     ///
     /// - Parameters:


### PR DESCRIPTION
In your current implementation of ChartIQView there is a retain cycle.

In your code, ChartIQView retains WKWebView, WKWebView retains WKWebViewConfiguration, WKWebViewConfiguration retains WKUserContentController and your WKUserContentController retains your ChartIQView. This is because it is added as the message handler in e.g. userContentController.add(self, name: ChartIQCallbackMessage.accessibility.rawValue)

Thus when using ChartIQView one has to be able to remove scriptHandler by calling removeScriptMessageHandlerForName, in e.g. the deinit method if it superview.