### PR TITLE
Logging

### DIFF
--- a/ChartIQ/Charts/ChartIQView.swift
+++ b/ChartIQ/Charts/ChartIQView.swift
@@ -302,6 +302,7 @@ public class ChartIQView: UIView {
         case layout = "layoutHandler"
         case drawing = "drawingHandler"
         case accessibility = "accessibilityHandler"
+        case log = "logHandler"
     }
     
     internal static var isValidApiKey = false
@@ -576,7 +577,8 @@ public class ChartIQView: UIView {
         userContentController.add(self, name: ChartIQCallbackMessage.pullPaginationData.rawValue)
         userContentController.add(self, name: ChartIQCallbackMessage.layout.rawValue)
         userContentController.add(self, name: ChartIQCallbackMessage.drawing.rawValue)
-        
+        userContentController.add(self, name: ChartIQCallbackMessage.log.rawValue)
+
         // Create the configuration with the user content controller
         let configuration = WKWebViewConfiguration()
         configuration.userContentController = userContentController
@@ -1334,6 +1336,21 @@ extension ChartIQView: WKScriptMessageHandler {
                     UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, quote);
                 }
             }
+        // Allows for various console messages from JavaScript to show up in Xcode console.
+        // Accepted console methods are "log," "warning," and "error".
+        case .log:
+            let message = message.body as! [String: Any]
+            let method = message["method"] as? String ?? "LOG"
+            let arguments = message["arguments"] as! [String: String]
+            var msg: String = ""
+            for (_, value) in arguments {
+                if (msg.characters.count > 0) {
+                    msg += "\n"
+                }
+                
+                msg += value
+            }
+            NSLog("%@: %@", method, msg)
         }
     }
 }
@@ -1347,4 +1364,3 @@ extension ChartIQView : WKNavigationDelegate {
     }
     
 }
-

--- a/ChartIQ/Charts/ChartIQView.swift
+++ b/ChartIQ/Charts/ChartIQView.swift
@@ -618,6 +618,8 @@ public class ChartIQView: UIView {
         clear()
         _dataMethod = method
         addEvent("CHIQ_setDataMethod", parameters: ["method": method == .pull ? "PULL" : "PUSH"])
+        let script = "determineOs()"
+        webView.evaluateJavaScript(script, completionHandler: nil)
         if method == .pull {
             let script = "attachQuoteFeed(\(ChartIQView.refreshInterval))";
             webView.evaluateJavaScript(script, completionHandler: nil)

--- a/ChartIQ/Charts/ChartIQView.swift
+++ b/ChartIQ/Charts/ChartIQView.swift
@@ -1338,9 +1338,9 @@ extension ChartIQView: WKScriptMessageHandler {
                     UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, quote);
                 }
             }
+        case .log:
         // Allows for various console messages from JavaScript to show up in Xcode console.
         // Accepted console methods are "log," "warning," and "error".
-        case .log:
             let message = message.body as! [String: Any]
             let method = message["method"] as? String ?? "LOG"
             let arguments = message["arguments"] as! [String: String]

--- a/ChartIQDemo/ChartIQDemo/AppDelegate.swift
+++ b/ChartIQDemo/ChartIQDemo/AppDelegate.swift
@@ -13,7 +13,7 @@ import ChartIQ
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
-    let url = "http://yourdeployment/template-native-sdk.html"
+    let url = "http://yourdeployment/sample-template-native-sdk.html"
     let apiKey = ""
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {


### PR DESCRIPTION
Resolves ticket [3436](https://chartiq.kanbanize.com/ctrl_board/15/cards/3436/details).

- Allows console logs written in the Native Wrappers to be sent back to the native application log.  This functionality already exists in the Android project, so some changes were made to allow to work for iOS without affecting Android.
- Logging won't work without code changes on ["native-logging" branch of the stx repo](https://github.com/ChartIQ/stx/pull/1186) applied as well.