### PR TITLE
5859 active studies

### DIFF
--- a/ChartIQ/Charts/ChartIQView.swift
+++ b/ChartIQ/Charts/ChartIQView.swift
@@ -1053,7 +1053,7 @@ public class ChartIQView: UIView {
         var addedStudy = [Study]()
         let script = "getAddedStudies();"
         if let listString = webView.evaluateJavaScriptWithReturn(script), !listString.isEmpty {
-            let list = listString.components(separatedBy: "|||")
+            let list = listString.components(separatedBy: "||")
             list.forEach({ (study) in
                 let components = study.components(separatedBy: "___")
                 var name = components[0]

--- a/ChartIQ/Charts/ChartIQView.swift
+++ b/ChartIQ/Charts/ChartIQView.swift
@@ -1056,7 +1056,12 @@ public class ChartIQView: UIView {
             let list = listString.components(separatedBy: "|||")
             list.forEach({ (study) in
                 let components = study.components(separatedBy: "___")
-                let name = components[0]
+                var name = components[0]
+                /// Swift seems to have trouble parsing out the zwnb from pipe used to separate our studies
+                if name.contains("|\u{200c}") {
+                    name.remove(at: name.startIndex)
+                    name.insert("\u{200c}", at: name.startIndex)
+                    }
                 let inputString = components[1]
                 let outputString = components[2]
                 var inputs: [String: Any]?


### PR DESCRIPTION
Kanbanize [5859]() Fixes studies only displaying first active study to edit.

Zero width non-Joiners are necessary for the study names to match and be editable, but don't seem to split correctly around `|`. Parsing them out and adding zwnj as needed fixes this.