### PR TITLE
Fix 15496 Invoke Call Not Working

### DIFF
--- a/ChartIQ/Charts/ChartIQView.swift
+++ b/ChartIQ/Charts/ChartIQView.swift
@@ -968,7 +968,7 @@ public class ChartIQView: UIView {
         let jsonData = try! JSONSerialization.data(withJSONObject: args, options: .prettyPrinted)
         let json = String(data: jsonData, encoding: .utf8)?.replacingOccurrences(of: "\n", with: "") ?? ""
         
-        let script = "stxx.\(functionName)(\(json));"
+        let script = "stxx.\(functionName)(\(json.dropFirst().dropLast()));"
         let value = webView.evaluateJavaScriptWithReturn(script)
         var result = ""
 


### PR DESCRIPTION
Currently when the `invoke` function is used to invoke JavaScript functions, it bundles up any arguments into an array and calls the JavaScript function with all parameters as members of said array. This does not work for JavaScript functions that expect arguments to be passed in positionally. 

To test, add this code to `sample-template-native-sdk.html`:
```javascript
stxx.testInvoke = function(arg1, arg2) {
	if (arg1) {
		if (typeof(arg1) === "object") {
			console.log(JSON.stringify(arg1))
		} else {
			console.log(arg1)
		}
	}
	if (arg2) {
		console.log(arg2)
	}
}
```

Also add this code to `chartIQViewDidFinishLoading` in `ViewController.swift`:
```swift
chartIQView.invoke(functionName: "testInvoke", args: "a", "b")
```

Notice that before the fix, this will log `["a","b"]`, an array of arguments passed to the JavaScript function. With the fix, this will load `a` and then `b`.