### PR TITLE
15588 Chart in WKWebView resizing to wrong size after rotation

### DIFF
--- a/ChartIQDemo/ChartIQDemo/ViewController.swift
+++ b/ChartIQDemo/ChartIQDemo/ViewController.swift
@@ -89,6 +89,8 @@ class ViewController: UIViewController {
             setupSearchStudiesController(viewController)
         }
     }
+
+    // MARK: - Layout
     
     func setupNavigationBar() {
         periodButton = UIButton(type: .custom)

--- a/ChartIQDemo/ChartIQDemo/ViewController.swift
+++ b/ChartIQDemo/ChartIQDemo/ViewController.swift
@@ -89,14 +89,6 @@ class ViewController: UIViewController {
             setupSearchStudiesController(viewController)
         }
     }
-
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        coordinator.animate(alongsideTransition: nil, completion: { context in
-            self.chartIQView.resizeChart()
-        })
-    }
-
-    // MARK: - Layout
     
     func setupNavigationBar() {
         periodButton = UIButton(type: .custom)


### PR DESCRIPTION
The PR is a part of ticket [15588](https://chartiq.kanbanize.com/ctrl_board/15/cards/15588). 

Most of the change takes place on the `stx` side, but we also need to clean up the old solution here. See https://github.com/ChartIQ/stx/pull/1896 for more info.
