### PR TITLE
31280 Legacy iOS mobile apps crashing

### DIFF
--- a/ChartIQ/Charts/ChartIQView.swift
+++ b/ChartIQ/Charts/ChartIQView.swift
@@ -1007,7 +1007,7 @@ public class ChartIQView: UIView {
             "   var input = helper.inputs[x]; " +
             "   if (input[\"name\"] === \"\(parameter)\") { " +
             "       isFound = true; " +
-            "       if (input[\"type\"] === \"text\" || input[\"type\"] === \"select\") { " +
+            "       if (input[\"type\"] === \"text\" || input[\"type\"] === \"select\" || input[\"type\"] === \"date\" || input[\"type\"] === \"time\") { " +
             "           newInputParameters[\"\(parameter)\"] = \"\(value)\"; " +
             "       } else if (input[\"type\"] === \"number\") { " +
             "           newInputParameters[\"\(parameter)\"] = parseFloat(\"\(value)\"); " +

--- a/ChartIQDemo/ChartIQDemo/StudyDetailViewController.swift
+++ b/ChartIQDemo/ChartIQDemo/StudyDetailViewController.swift
@@ -24,9 +24,13 @@ class StudyDetailViewController: UITableViewController {
         case color = "color"
         case text = "text"
         case colorText = "colorText"
+        case date = "date"
+        case time = "time"
         
         var cellIdentifier: String {
             switch self {
+            case .date: return "StudyValueTableCell"
+            case .time: return "StudyValueTableCell"
             case .select: return "StudyListTableCell"
             case .number: return "StudyValueTableCell"
             case .text: return "StudyValueTableCell"
@@ -241,7 +245,7 @@ class StudyDetailViewController: UITableViewController {
         switch optionType {
         case .select:
             cell.labels?[1].text = (parameter["value"] as? String)?.capitalized ?? ""
-        case .number, .text:
+        case .number, .text, .date, .time:
             cell.textFields![0].keyboardType = optionType == .number ? .numberPad : .default
             cell.textFields?[0].text = optionType == .number ? String(parameter["value"] as? Float ?? 0) : parameter["value"] as? String ?? ""
             cell.textFieldValueDidEndEditingBlock = {[weak self] (cell, textField) in

--- a/ChartIQDemo/ChartIQDemo/StudyDetailViewController.swift
+++ b/ChartIQDemo/ChartIQDemo/StudyDetailViewController.swift
@@ -248,6 +248,12 @@ class StudyDetailViewController: UITableViewController {
         case .number, .text, .date, .time:
             cell.textFields![0].keyboardType = optionType == .number ? .numberPad : .default
             cell.textFields?[0].text = optionType == .number ? String(parameter["value"] as? Float ?? 0) : parameter["value"] as? String ?? ""
+            if(optionType == .date) {
+                cell.labels?[0].text! += " (yyyymmdd)"
+            }
+            if(optionType == .time) {
+                cell.labels?[0].text! += " (hh:mm:ss)"
+            }
             cell.textFieldValueDidEndEditingBlock = {[weak self] (cell, textField) in
                 guard let strongSelf = self else { return }
                 let name = cell.labels![0].text ?? ""

--- a/ChartIQDemo/ChartIQDemo/StudyDetailViewController.swift
+++ b/ChartIQDemo/ChartIQDemo/StudyDetailViewController.swift
@@ -248,12 +248,6 @@ class StudyDetailViewController: UITableViewController {
         case .number, .text, .date, .time:
             cell.textFields![0].keyboardType = optionType == .number ? .numberPad : .default
             cell.textFields?[0].text = optionType == .number ? String(parameter["value"] as? Float ?? 0) : parameter["value"] as? String ?? ""
-            if(optionType == .date) {
-                cell.labels?[0].text! += " (yyyymmdd)"
-            }
-            if(optionType == .time) {
-                cell.labels?[0].text! += " (hh:mm:ss)"
-            }
             cell.textFieldValueDidEndEditingBlock = {[weak self] (cell, textField) in
                 guard let strongSelf = self else { return }
                 let name = cell.labels![0].text ?? ""


### PR DESCRIPTION
Allow date and time parameters to be processed correctly. The date and time fields are just text boxes. We don't have the time to spend on the legacy apps to implement a date and time picker. 