### PR TITLE
31334 support study parameters

### DIFF
--- a/ChartIQ/Charts/ChartIQView.swift
+++ b/ChartIQ/Charts/ChartIQView.swift
@@ -748,7 +748,6 @@ public class ChartIQView: UIView {
     ///   - key: The parameter name that must be defined in CIQ.Studies.DialogHelper
     ///   - value: The value
     public func setStudy(_ name: String, withParameter key: String, value: String) {
-        NSLog("SETSTUDY KEY VALUE")
         let script = "setStudy(\"\(name)\", \"\(key)\", \"\(value)\")"
         webView.evaluateJavaScript(script, completionHandler: nil)
     }
@@ -759,7 +758,6 @@ public class ChartIQView: UIView {
     ///   - name: The study name
     ///   - parameter: The parameter name that must be defined in CIQ.Studies.DialogHelper
     public func setStudy(_ name: String, parameters: [String: String]) {
-        NSLog("SETSTUDY PARAMETER OBJECT")
         var script = getStudyDescriptorScript(with: name) +
             "var helper = new CIQ.Studies.DialogHelper({sd:selectedSd,stx:stxx}); " +
             "var isFound = false; " +
@@ -768,13 +766,8 @@ public class ChartIQView: UIView {
             "var newParameterParameters = {}; "
     
         parameters.forEach { (parameter) in
-            //NSLog("Study Parameter: %@:%@", parameter.key, parameter.value)
             script += getUpdateStudyParametersScript(parameter: parameter.key, value: parameter.value)
         }
-        
-        //script += "helper.updateStudy({inputs:newInputParameters, outputs:newOutputParameters, parameters: {studyOverBoughtColor: '#ff0000', studyOverBoughtValue: '80', studyOverSoldColor: '#00ff00', studyOverSoldValue: '20'}}); "
-        
-        //script += "webkit.messageHandlers.logHandler.postMessage({\"method\": \"LOG\", \"arguments\": JSON.stringify(newParameterParameters)});"
         
         script += "helper.updateStudy({inputs:newInputParameters, outputs:newOutputParameters, parameters: newParameterParameters}); "
         
@@ -1040,22 +1033,6 @@ public class ChartIQView: UIView {
             "       newParameterParameters[\"\(parameter)\"] = \"\(value)\"; " +
             "   } " +
             "} " +
-//            "   for (x in helper.parameters) { " +
-//            "       var parameter = helper.parameters[x]; " +
-//            "webkit.messageHandlers.logHandler.postMessage({\"method\": \"LOG\", \"arguments\": JSON.parse(JSON.stringify({name: parameter[\"name\"]}))});" +
-//            "       if (parameter[\"name\"] === \"\(parameter)\") { " +
-////            "webkit.messageHandlers.logHandler.postMessage({\"method\": \"LOG\", \"arguments\": JSON.parse(JSON.stringify({name: \"Looking for studyOverBought\"}))});" +
-////            "           if ( parameter[\"name\"] === \"studyOverBought\" || parameter[\"name\"] === \"studyOverSold\" ) {" +
-////            "webkit.messageHandlers.logHandler.postMessage({\"method\": \"LOG\", \"arguments\": JSON.parse(JSON.stringify({type: parameter[\"type\"]}))});" +
-////            "               newParameterParameters[\"\(parameter)Color\"] = \"\(value)\"; " +
-////           // "               newParameterParameters[\"\(parameter)\"Color] = \"\(color)\"; " +
-////            "           if (parameter[\"type\"] === \"checkbox\") { " +
-////            "               newParameterParameters[\"\(parameter)\"] = \(value == "false" ? false : true); " +
-//            "           } else {" +
-//            "               newParameterParameters[\"\(parameter)\"] = \"\(value)\"; " +
-// //           "           }" +
-//            "       } " +
-//            "   } " +
             "isFound = false;"
         return updateParametersScript
     }

--- a/ChartIQ/Charts/ChartIQView.swift
+++ b/ChartIQ/Charts/ChartIQView.swift
@@ -748,6 +748,7 @@ public class ChartIQView: UIView {
     ///   - key: The parameter name that must be defined in CIQ.Studies.DialogHelper
     ///   - value: The value
     public func setStudy(_ name: String, withParameter key: String, value: String) {
+        NSLog("SETSTUDY KEY VALUE")
         let script = "setStudy(\"\(name)\", \"\(key)\", \"\(value)\")"
         webView.evaluateJavaScript(script, completionHandler: nil)
     }
@@ -758,17 +759,24 @@ public class ChartIQView: UIView {
     ///   - name: The study name
     ///   - parameter: The parameter name that must be defined in CIQ.Studies.DialogHelper
     public func setStudy(_ name: String, parameters: [String: String]) {
+        NSLog("SETSTUDY PARAMETER OBJECT")
         var script = getStudyDescriptorScript(with: name) +
             "var helper = new CIQ.Studies.DialogHelper({sd:selectedSd,stx:stxx}); " +
             "var isFound = false; " +
             "var newInputParameters = {}; " +
-            "var newOutputParameters = {}; "
+            "var newOutputParameters = {}; " +
+            "var newParameterParameters = {}; "
     
         parameters.forEach { (parameter) in
+            //NSLog("Study Parameter: %@:%@", parameter.key, parameter.value)
             script += getUpdateStudyParametersScript(parameter: parameter.key, value: parameter.value)
         }
         
-        script += "helper.updateStudy({inputs:newInputParameters, outputs:newOutputParameters}); "
+        //script += "helper.updateStudy({inputs:newInputParameters, outputs:newOutputParameters, parameters: {studyOverBoughtColor: '#ff0000', studyOverBoughtValue: '80', studyOverSoldColor: '#00ff00', studyOverSoldValue: '20'}}); "
+        
+        //script += "webkit.messageHandlers.logHandler.postMessage({\"method\": \"LOG\", \"arguments\": JSON.stringify(newParameterParameters)});"
+        
+        script += "helper.updateStudy({inputs:newInputParameters, outputs:newOutputParameters, parameters: newParameterParameters}); "
         
         webView.evaluateJavaScript(script, completionHandler: nil)
     }
@@ -1020,10 +1028,34 @@ public class ChartIQView: UIView {
             "   for (x in helper.outputs) { " +
             "       var output = helper.outputs[x]; " +
             "       if (output[\"name\"] === \"\(parameter)\") { " +
+            "           isFound = true; " +
             "           newOutputParameters[\"\(parameter)\"] = \"\(value)\"; " +
             "       } " +
             "   } " +
             "} " +
+            "if (isFound == false) { " +
+            "   if ( \"\(parameter)\" === \"studyOverBoughtValue\" || \"\(parameter)\" === \"studyOverSoldValue\" ) {" +
+            "       newParameterParameters[\"\(parameter)\"] = parseFloat(\"\(value)\"); " +
+            "   }else{" +
+            "       newParameterParameters[\"\(parameter)\"] = \"\(value)\"; " +
+            "   } " +
+            "} " +
+//            "   for (x in helper.parameters) { " +
+//            "       var parameter = helper.parameters[x]; " +
+//            "webkit.messageHandlers.logHandler.postMessage({\"method\": \"LOG\", \"arguments\": JSON.parse(JSON.stringify({name: parameter[\"name\"]}))});" +
+//            "       if (parameter[\"name\"] === \"\(parameter)\") { " +
+////            "webkit.messageHandlers.logHandler.postMessage({\"method\": \"LOG\", \"arguments\": JSON.parse(JSON.stringify({name: \"Looking for studyOverBought\"}))});" +
+////            "           if ( parameter[\"name\"] === \"studyOverBought\" || parameter[\"name\"] === \"studyOverSold\" ) {" +
+////            "webkit.messageHandlers.logHandler.postMessage({\"method\": \"LOG\", \"arguments\": JSON.parse(JSON.stringify({type: parameter[\"type\"]}))});" +
+////            "               newParameterParameters[\"\(parameter)Color\"] = \"\(value)\"; " +
+////           // "               newParameterParameters[\"\(parameter)\"Color] = \"\(color)\"; " +
+////            "           if (parameter[\"type\"] === \"checkbox\") { " +
+////            "               newParameterParameters[\"\(parameter)\"] = \(value == "false" ? false : true); " +
+//            "           } else {" +
+//            "               newParameterParameters[\"\(parameter)\"] = \"\(value)\"; " +
+// //           "           }" +
+//            "       } " +
+//            "   } " +
             "isFound = false;"
         return updateParametersScript
     }

--- a/ChartIQDemo/ChartIQDemo/StudyDetailViewController.swift
+++ b/ChartIQDemo/ChartIQDemo/StudyDetailViewController.swift
@@ -135,8 +135,6 @@ class StudyDetailViewController: UITableViewController {
             guard let strongSelf = self else { return }
             if strongSelf.selectedCellIndex > (strongSelf.outputParameter.count + strongSelf.inputParameter.count) {
                 var parameter = strongSelf.paramParameter[strongSelf.selectedColorIndex]
-                // strongSelf.selectedColorIndex is 8, the length of all parameters. Need to set the index relative to the paramParameters array
-                //var parameter = strongSelf.paramParameter[3]
                 parameter["color"] = color.toHexString()
                 strongSelf.paramParameter![strongSelf.selectedCellIndex - (strongSelf.inputParameter.count + strongSelf.outputParameter.count)] = parameter
                 strongSelf.tableView.reloadData()

--- a/ChartIQDemo/ChartIQDemo/StudyDetailViewController.swift
+++ b/ChartIQDemo/ChartIQDemo/StudyDetailViewController.swift
@@ -135,6 +135,8 @@ class StudyDetailViewController: UITableViewController {
             guard let strongSelf = self else { return }
             if strongSelf.selectedCellIndex > (strongSelf.outputParameter.count + strongSelf.inputParameter.count) {
                 var parameter = strongSelf.paramParameter[strongSelf.selectedColorIndex]
+                // strongSelf.selectedColorIndex is 8, the length of all parameters. Need to set the index relative to the paramParameters array
+                //var parameter = strongSelf.paramParameter[3]
                 parameter["color"] = color.toHexString()
                 strongSelf.paramParameter![strongSelf.selectedCellIndex - (strongSelf.inputParameter.count + strongSelf.outputParameter.count)] = parameter
                 strongSelf.tableView.reloadData()
@@ -166,7 +168,12 @@ class StudyDetailViewController: UITableViewController {
         }
         var parameters = [String: Any]()
         for parameter in paramParameter {
-            parameters[parameter["name"] as! String] = parameter["value"]!
+            if( parameter["name"] as! String == "studyOverBought" || parameter["name"] as! String == "studyOverSold" ){
+                parameters[(parameter["name"] as! String)+"Color"] = parameter["color"]!
+                parameters[(parameter["name"] as! String)+"Value"] = parameter["value"]!
+            }else if( parameter["value"] != nil ){
+                parameters[parameter["name"] as! String] = parameter["value"]!
+            }
         }
         study.inputs = inputs
         study.outputs = outputs


### PR DESCRIPTION
Resolves ticket [31334](https://cosaic.kanbanize.com/ctrl_board/15/cards/31334/details/).

Adds support for study parameter parameters. There were two issues here. First, the study `parameters` were not sent to the bridge. Second, the app could not handle a parameter value that had both a number and a color. For the latter, this is doing a hard check for `studyOverBought` and `studyOverSold` and splitting them out to "Value" and "Color" parameters as needed by the library. This should be handled in a more flexible way but since this project is being phased out, and the new app does not have this issue, checking for the hard coded names is acceptable.

To test:
- Set up the native app bridge on a local server and start up the app simulator. IMPORTANT: The legacy app isn't compatible with v8. I've been using a build off the 7.5 branch.
- Add a Bollinger %b study, or any study that uses Over Bought/Sold
- Try changing the values and colors for Over Bought & Over Sold